### PR TITLE
Preemptive fixes for out of range victim and attacker id's #480

### DIFF
--- a/addons/sourcemod/scripting/ttt/core/sql.sp
+++ b/addons/sourcemod/scripting/ttt/core/sql.sp
@@ -19,6 +19,20 @@ public void SQL_AlterKarmaColumn(Database db, DBResultSet results, const char[] 
     }
 }
 
+public void SQL_AlterIDColumn(Database db, DBResultSet results, const char[] error, any data)
+{
+    if (db == null || strlen(error) > 0)
+    {
+        LogError("(SQL_AlterIDColumn) Query failed: %s", error);
+        
+        return;
+    }
+    else
+    {
+        LateLoadClients(false);
+    }
+}
+
 public void SQL_AlterRSlaysColumn(Database db, DBResultSet results, const char[] error, any data)
 {
     if (db == null || strlen(error) > 0)

--- a/addons/sourcemod/scripting/ttt/rdm/database.sp
+++ b/addons/sourcemod/scripting/ttt/rdm/database.sp
@@ -1,11 +1,23 @@
+
+
 void Db_InsertDeath(int victim, int attacker)
 {
     int victimId = TTT_GetPlayerID(victim);
+    if (victimId < 1)
+    {
+        LogError("Invalid TTT_PlayerID in 'Db_InsertDeath' from client %d", victim);
+        return;
+    }
     int victimRole = TTT_GetClientRole(victim);
     char sVictimRole[10] = "none";
     RoleEnum(sVictimRole, sizeof(sVictimRole), victimRole);
 
     int attackerId = TTT_GetPlayerID(attacker);
+    if (attackerId < 1)
+    {
+        LogError("Invalid TTT_PlayerID in 'Db_InsertDeath' from client %d", attacker);
+        return;
+    }
     int attackerRole = TTT_GetClientRole(attacker);
     char sAttackerRole[10] = "none";
     RoleEnum(sAttackerRole, sizeof(sAttackerRole), attackerRole);

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -274,6 +274,7 @@ public void OnConfigsExecuted()
 public void TTT_OnSQLConnect(Database db)
 {
     g_dDB = db;
+    AlterIDColumn();
     AlterNameColumn();
     AlterKarmaColumn();
     AlterRSlaysColumn();
@@ -282,6 +283,21 @@ public void TTT_OnSQLConnect(Database db)
     if (g_cSaveLogsInSQL.BoolValue)
     {
         CreateLogTable();
+    }
+}
+
+void AlterIDColumn()
+{
+    if (g_dDB != null)
+    {
+        char sQuery[76];
+        g_dDB.Format(sQuery, sizeof(sQuery), "ALTER TABLE `ttt` MODIFY COLUMN `id` INT UNSIGNED NOT NULL AUTO_INCREMENT;");
+        g_dDB.Query(SQL_AlterIDColumn, sQuery);
+    }
+    else
+    {
+        SetFailState("(AlterRSlaysColumn) Database handle is invalid!");
+        return;
     }
 }
 

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -296,7 +296,7 @@ void AlterIDColumn()
     }
     else
     {
-        SetFailState("(AlterRSlaysColumn) Database handle is invalid!");
+        SetFailState("(AlterIDColumn) Database handle is invalid!");
         return;
     }
 }

--- a/addons/sourcemod/scripting/ttt/ttt_sql.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_sql.sp
@@ -162,7 +162,7 @@ void Call_OnSQLConnect()
 void CheckAndCreateTables()
 {
     char sQuery[256];
-    Format(sQuery, sizeof(sQuery), "CREATE TABLE IF NOT EXISTS `ttt` ( `id` INT NOT NULL AUTO_INCREMENT , `communityid` VARCHAR(64) NOT NULL , PRIMARY KEY (`id`), UNIQUE (`communityid`)) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;");
+    Format(sQuery, sizeof(sQuery), "CREATE TABLE IF NOT EXISTS `ttt` ( `id` INT UNSIGNED NOT NULL AUTO_INCREMENT , `communityid` VARCHAR(64) NOT NULL , PRIMARY KEY (`id`), UNIQUE (`communityid`)) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;");
 
     TTT_Query("Callback_CheckAndCreateTables", sQuery);
 


### PR DESCRIPTION
Not yet been able to replicate the error but added some extra logging to see where it is going wrong also made the ttt player id unsigned though it shouldn't matter.

L 08/23/2020 - 10:03:25: [ttt/ttt_rdm.smx] DbCallback_InsertDeath: Out of range value for column 'victim_id' at row 1

This error generally means the value is out of range, so would seem that `TTT_GetPlayerID` is returning -1 or something or other, which is the cause of the problem, shall try reproducing on a local server again.

We may need to validate Player ID's in `SQL_OnClientPutInServer` incase -1 is returned.
To also look to fix this I have made the `ttt` tables `id` column be unsigned to match that of RDM but noone should really be having that many players in there database anyway.