### PR TITLE
Fix RDM Manager reporting kills post round.

### DIFF
--- a/addons/sourcemod/scripting/ttt/ttt_rdm.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_rdm.sp
@@ -168,7 +168,7 @@ public void TTT_OnClientDeath(int victim, int attacker)
         TTT_GetClientName(attacker, sAttackerName, sizeof(sAttackerName));
         TTT_GetClientName(victim, sVictimName, sizeof(sVictimName));
 
-        CPrintToChatAdmins(ADMFLAG_GENERIC, "%T", "RDM: Staff Bad Action Report", LANG_SERVER, sAttackerName, attackerKarma, sAttackerName, victimKarma);
+        CPrintToChatAdmins(ADMFLAG_GENERIC, "%T", "RDM: Staff Bad Action Report", LANG_SERVER, sAttackerName, attackerKarma, sVictimName, victimKarma);
     }
 
     Db_InsertDeath(victim, attacker);

--- a/addons/sourcemod/scripting/ttt/ttt_rdm.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_rdm.sp
@@ -299,6 +299,9 @@ void RoleEnum(char[] buffer, int maxlength, int role)
 
 bool BadKill(int attackerRole, int victimRole)
 {
+    if (TTT_GetRoundStatus() != Round_Active)
+        return false;
+
     if (attackerRole == victimRole) return true;
     //else if (attackerRole == TTT_TEAM_TRAITOR || victimRole == TTT_TEAM_TRAITOR) return false;
     else if ((attackerRole | victimRole) & TTT_TEAM_TRAITOR) return false;


### PR DESCRIPTION
If you have the convar ``ttt_roundend_dm "1"`` enabled, then kills are reported as RDM at the end of the round. This will ensure this does not happen.