### PR TITLE
Fix English (en) pronouns

### DIFF
--- a/addons/sourcemod/scripting/ttt/ttt_bodies.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_bodies.sp
@@ -1252,14 +1252,14 @@ void InspectBody(int client, int victim, int victimRole, int attacker, int time,
     {
         static char sTime[128];
         static char sWeaponUsed[128];
-        Format(sTime, sizeof(sTime), "%T", "Elapsed since his death", client, time);
+        Format(sTime, sizeof(sTime), "%T", "Elapsed since their death", client, time);
         if (attacker > 0 && attacker != victim)
         {
             Format(sWeaponUsed, sizeof(sWeaponUsed), "%T", "The weapon used has been", client, weapon);
         }
         else
         {
-            Format(sWeaponUsed, sizeof(sWeaponUsed), "%T", "The weapon used has been: himself (suicide)", client);
+            Format(sWeaponUsed, sizeof(sWeaponUsed), "%T", "The weapon used has been: themself (suicide)", client);
         }
         
         Format(sBuffer, sizeof(sBuffer), "<center><pre><font color=\"#FFFFFF\"><font size=\"48\">%s (%s)</font>\n<font size=\"32\">%s\n%s</font></font></pre></center>", victimName, team, sTime, sWeaponUsed);

--- a/addons/sourcemod/translations/ttt.phrases.txt
+++ b/addons/sourcemod/translations/ttt.phrases.txt
@@ -239,7 +239,7 @@
 
 	"The weapon used has been: himself (suicide)"
 	{
-		"en"		"Himself (suicide)"
+		"en"		"Themself (suicide)"
 		"chi"		"自杀"
 		"de"		"Selbst (Suizid)"
 		"pl"		"On sam (samobójstwo)"
@@ -997,7 +997,7 @@
 	"You tased a Traitor"
 	{
 		"#format"	"{1:s},{2:s}"
-		"en"		"Scan Complete: {player}{1} {default}scanned {role t}{2} {default}and he is a {role t}Traitor{default}!"
+		"en"		"Scan Complete: {player}{1} {default}scanned {role t}{2} {default}and they are a {role t}Traitor{default}!"
 		"chi"		"扫描完成：{player}{1} {default}扫描了 {role t}{2} {default}发现他/她是{role t}叛徒{default}！"
 		"de"		"Untersuchung abgeschlossen: {player}{1} {default}scannt {role t}{2} {default}und ist ein{role t}Traitor{default}!"
 		"pl"		"Skan ukończony: {player}{1} {default}przeskanował {role t}{2} {default}i jest {role t}Zdrajcą{default}!"
@@ -1006,7 +1006,7 @@
 	"You tased a Detective"
 	{
 		"#format"	"{1:s},{2:s}"
-		"en"		"Scan Complete: {player}{1} {default}scanned {role d}{2} {default}and he is a {role d}Detective{default}!"
+		"en"		"Scan Complete: {player}{1} {default}scanned {role d}{2} {default}and they are a {role d}Detective{default}!"
 		"chi"		"扫描完成：{player}{1} {default}扫描了 {role d}{2} {default}发现他/她是{role d}警探{default}！"
 		"de"		"Untersuchung abgeschlossen: {player}{1} {default}scannt {role d}{2} {default}und ist ein {role d}Detektiv{default}!"
 		"pl"		"Skan ukończony: {player}{1} {default}przeskanował {role d}{2} {default}i jest {role d}Detektywem{default}!"
@@ -1015,7 +1015,7 @@
 	"You tased an Innocent"
 	{
 		"#format"	"{1:s},{2:s}"
-		"en"		"Scan Complete: {player}{1} {default}scanned {role i}{2} {default}and he is {role i}Innocent{default}!"
+		"en"		"Scan Complete: {player}{1} {default}scanned {role i}{2} {default}and they are {role i}Innocent{default}!"
 		"chi"		"扫描完成：{player}{1} {default}扫描了 {role i}{2} {default}发现他/她是{role i}平民{default}！"
 		"de"		"Untersuchung abgeschlossen: {player}{1} {default}scannt {role i}{2} {default}und ist ein {role i}Innocent{default}!"
 		"pl"		"Skan ukończony: {player}{1} {default}przeskanował {role i}{2} {default}i jest {role i}Niewinnym{default}!"

--- a/addons/sourcemod/translations/ttt.phrases.txt
+++ b/addons/sourcemod/translations/ttt.phrases.txt
@@ -219,7 +219,7 @@
 		"pl"		"rola: {1}"
 	}
 
-	"Elapsed since his death"
+	"Elapsed since their death"
 	{
 		"#format"	"{1:i}"
 		"en"		"Time since Death: {1} second(s)"
@@ -237,7 +237,7 @@
 		"pl"		"Broń mordercy: {1}"
 	}
 
-	"The weapon used has been: himself (suicide)"
+	"The weapon used has been: themself (suicide)"
 	{
 		"en"		"Themself (suicide)"
 		"chi"		"自杀"

--- a/addons/sourcemod/translations/ttt_rdm.phrases.txt
+++ b/addons/sourcemod/translations/ttt_rdm.phrases.txt
@@ -43,7 +43,7 @@
     "RDM: Staff Info - Last Shot"
     {
         "#format"   "{1:d}"
-        "en"        "The victim had shot last {highlight}{1} {default}seconds before there death."
+        "en"        "The victim had shot last {highlight}{1} {default}seconds before their death."
         "chi"       "受害者在死亡前 {highlight}{1} {default}秒进行了反击。"
     }
 


### PR DESCRIPTION
Replaced gendered (he/him/his) pronouns in `ttt.phrases.txt` with gender-neutral (they/them/theirs) pronouns. Also fixed small pronoun-typo in `ttt_rdm.phrases.txt`.